### PR TITLE
Add psalm-pure for static factory methods

### DIFF
--- a/src/Aeon/Calendar/Gregorian/YasumiHolidays.php
+++ b/src/Aeon/Calendar/Gregorian/YasumiHolidays.php
@@ -37,6 +37,9 @@ final class YasumiHolidays implements Holidays
         $this->year = $year;
     }
 
+    /**
+     * @psalm-pure
+     */
     public static function provider(string $providerClass, int $year) : self
     {
         return new self($providerClass, $year);


### PR DESCRIPTION
Adds missing `psalm-pure` annotation on static factory methods.